### PR TITLE
cherry-pick: support visit remote kubefin dashboard(not localhost)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -43,7 +43,17 @@ npm install
 
 ### Start dashboard
 
-Once you've [set up your development environment](#prerequisites), run following command and `dashboard` can be launhed with the code you cloned:
+After you've [set up your development environment](#prerequisites), please config the API endpoint in file `dashboard/web/src/common/network/http-common.js`. For example, my API endpoint is `http://192.168.1.3:8080`:
+```
+import axios from "axios";
+
+export default axios.create({
+  baseURL: "http://192.168.1.3:8080/api/v1",
+});
+
+```
+
+Run following command and `dashboard` can be launhed with the code you cloned:
 ```sh
 cd web
 PORT=3001 npm start --host 0.0.0.0

--- a/nginx-config/default.conf
+++ b/nginx-config/default.conf
@@ -9,6 +9,14 @@ server {
         try_files $uri /index.html;                 
     }
 
+    location /api/v1 {
+        proxy_connect_timeout       180;
+        proxy_send_timeout          180;
+        proxy_read_timeout          180;
+        proxy_pass http://localhost:8080;
+        proxy_redirect off;
+    }
+
     error_page   500 502 503 504  /50x.html;
     location = /50x.html {
         root   /usr/share/nginx/html;

--- a/web/src/common/network/http-common.js
+++ b/web/src/common/network/http-common.js
@@ -1,5 +1,5 @@
 import axios from "axios";
 
 export default axios.create({
-  baseURL: "http:///localhost:8080/api/v1",
+  baseURL: "/api/v1",
 });


### PR DESCRIPTION
Related PR: https://github.com/kubefin/dashboard/pull/1

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Support following scenario: when I launch kubefin dashboard and run `kubectl port-forward` not in localhost.

support visit remote kubefin dashboard(not localhost)

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
dashboard: support access remote kubefin dashboard(not localhost)
```
